### PR TITLE
Fix - complement mask in denomiantor loglikelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Implementation of CRF (Conditional Random Fields) in PyTorch 1.0
 >>> batch_size = 2
 >>> sequence_size = 3
 >>> num_labels = 5
->>> mask = torch.FloatTensor([[1, 1, 1], [1, 1, 0]]) # (batch_size. sequence_size)
+>>> mask = torch.ByteTensor([[1, 1, 1], [1, 1, 0]]) # (batch_size. sequence_size)
 >>> labels = torch.LongTensor([[0, 2, 3], [1, 4, 1]])  # (batch_size, sequence_size)
 >>> hidden = torch.randn((batch_size, sequence_size, num_labels), requires_grad=True)
 >>> crf = CRF(num_labels)

--- a/TorchCRF/__init__.py
+++ b/TorchCRF/__init__.py
@@ -180,7 +180,7 @@ class CRF(nn.Module):
             # スコアの更新
             # update scores
             # (batch_size, num_labels)
-            score = score_t * mask_t + score * (1 - mask_t)
+            score = score_t * mask_t + score * (~ mask_t)
 
         # 末尾のスコアを足し合わせる
         # add the end score of each label

--- a/TorchCRF/__init__.py
+++ b/TorchCRF/__init__.py
@@ -173,6 +173,8 @@ class CRF(nn.Module):
             # prepare t-th mask of sequences in each sequence
             # (batch_size, 1)
             mask_t = mask[:, t].view(batch_size, 1).type(torch.ByteTensor)
+            mask_t = mask_t.cuda() if CRF.CUDA else mask_t
+
             # 各系列におけるt番目の系列ラベルの遷移確率
             # prepare the transition probability of the t-th sequence label
             # in each sequence

--- a/TorchCRF/__init__.py
+++ b/TorchCRF/__init__.py
@@ -15,8 +15,7 @@ class CRF(nn.Module):
         """
 
         if num_labels < 1:
-            raise ValueError(
-                'invalid number of labels: {0}'.format(num_labels))
+            raise ValueError("invalid number of labels: {0}".format(num_labels))
 
         super().__init__()
         self.num_labels = num_labels
@@ -37,9 +36,9 @@ class CRF(nn.Module):
         self.start_matrix = nn.Parameter(self.start_trans)
         self.end_matrix = nn.Parameter(self.end_trans)
 
-    def forward(self, h: torch.FloatTensor,
-                labels: torch.LongTensor,
-                mask: torch.FloatTensor) -> torch.FloatTensor:
+    def forward(
+        self, h: torch.FloatTensor, labels: torch.LongTensor, mask: torch.ByteTensor
+    ) -> torch.FloatTensor:
         """
 
         :param h: hidden matrix (seq_len, batch_size, num_labels)
@@ -55,8 +54,9 @@ class CRF(nn.Module):
 
         return log_numerator - log_denominator
 
-    def viterbi_decode(self, h: torch.FloatTensor,
-                       mask: torch.FloatTensor) -> List[List[int]]:
+    def viterbi_decode(
+        self, h: torch.FloatTensor, mask: torch.ByteTensor
+    ) -> List[List[int]]:
         """
         decode labels using viterbi algorithm
         :param h: hidden matrix (batch_size, seq_len, num_labels)
@@ -105,15 +105,20 @@ class CRF(nn.Module):
 
         # バッチ内のラベルを推定
         # predict labels of mini batch
-        best_paths = [self._viterbi_compute_best_path(i, seq_lens, score, path)
-                      for i in range(batch_size)]
+        best_paths = [
+            self._viterbi_compute_best_path(i, seq_lens, score, path)
+            for i in range(batch_size)
+        ]
 
         return best_paths
 
-    def _viterbi_compute_best_path(self, batch_idx: int,
-                                   seq_lens: torch.LongTensor,
-                                   score: List[torch.FloatTensor],
-                                   path: List[torch.LongTensor]) -> List[int]:
+    def _viterbi_compute_best_path(
+        self,
+        batch_idx: int,
+        seq_lens: torch.LongTensor,
+        score: List[torch.FloatTensor],
+        path: List[torch.LongTensor],
+    ) -> List[int]:
         """
         return labels using viterbi algorithm
         :param batch_idx: index of batch
@@ -128,20 +133,20 @@ class CRF(nn.Module):
         seq_end_idx = seq_lens[batch_idx] - 1
         # 系列の一番後ろのラベルを抽出
         # extract label of end sequence
-        _, best_last_label = \
-            (score[seq_end_idx][batch_idx] + self.end_trans).max(0)
+        _, best_last_label = (score[seq_end_idx][batch_idx] + self.end_trans).max(0)
         best_labels = [int(best_last_label)]
 
         # viterbiアルゴリズムにより，ラベルを後ろから推定
         # predict labels from back using viterbi algorithm
-        for p in reversed(path[: seq_end_idx]):
+        for p in reversed(path[:seq_end_idx]):
             best_last_label = p[batch_idx][best_labels[0]]
             best_labels.insert(0, int(best_last_label))
 
         return best_labels
 
-    def _compute_denominator_log_likelihood(self, h: torch.FloatTensor,
-                                            mask: torch.FloatTensor):
+    def _compute_denominator_log_likelihood(
+        self, h: torch.FloatTensor, mask: torch.ByteTensor
+    ):
         """
 
         compute the denominator term for the log-likelihood
@@ -167,7 +172,7 @@ class CRF(nn.Module):
             # 各系列の系列のt番目のマスクを用意
             # prepare t-th mask of sequences in each sequence
             # (batch_size, 1)
-            mask_t = mask[:, t].view(batch_size, 1)
+            mask_t = mask[:, t].view(batch_size, 1).type(torch.ByteTensor)
             # 各系列におけるt番目の系列ラベルの遷移確率
             # prepare the transition probability of the t-th sequence label
             # in each sequence
@@ -180,7 +185,7 @@ class CRF(nn.Module):
             # スコアの更新
             # update scores
             # (batch_size, num_labels)
-            score = score_t * mask_t + score * (~ mask_t)
+            score = score_t * mask_t + score * (~mask_t)
 
         # 末尾のスコアを足し合わせる
         # add the end score of each label
@@ -190,9 +195,8 @@ class CRF(nn.Module):
         return self.logsumexp(score, 1)
 
     def _compute_numerator_log_likelihood(
-            self, h: torch.FloatTensor,
-            y: torch.LongTensor,
-            mask: torch.FloatTensor) -> torch.FloatTensor:
+        self, h: torch.FloatTensor, y: torch.LongTensor, mask: torch.ByteTensor
+    ) -> torch.FloatTensor:
         """
         compute the numerator term for the log-likelihood
         :param h: hidden matrix (batch_size, seq_len, num_labels)
@@ -256,10 +260,10 @@ class CRF(nn.Module):
         nn.init.uniform_(self.start_trans, -0.1, 0.1)
         nn.init.uniform_(self.end_trans, -0.1, 0.1)
         if pad_idx is not None:
-            self.start_trans[pad_idx] = -10000.
-            self.trans_matrix[pad_idx, :] = -10000.
-            self.trans_matrix[:, pad_idx] = -10000.
-            self.trans_matrix[pad_idx, pad_idx] = 0.
+            self.start_trans[pad_idx] = -10000.0
+            self.trans_matrix[pad_idx, :] = -10000.0
+            self.trans_matrix[:, pad_idx] = -10000.0
+            self.trans_matrix[pad_idx, pad_idx] = 0.0
 
     @staticmethod
     def logsumexp(x: torch.FloatTensor, dim: int) -> torch.FloatTensor:
@@ -272,8 +276,7 @@ class CRF(nn.Module):
         """
 
         vmax, _ = x.max(dim)
-        return vmax + \
-            torch.log(torch.sum(torch.exp(x - vmax.unsqueeze(dim)), dim))
+        return vmax + torch.log(torch.sum(torch.exp(x - vmax.unsqueeze(dim)), dim))
 
     @staticmethod
     def myTensor(*args) -> torch.Tensor:

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -4,36 +4,33 @@ from TorchCRF import CRF
 
 
 class TestCRF(unittest.TestCase):
-
     def setUp(self):
 
         self.batch_size = 2
         self.sequence_size = 3
         self.num_labels = 5
         self.crf = CRF(self.num_labels)
-        self.mask = torch.FloatTensor([[1, 1, 1], [1, 1, 0]])
+        self.mask = torch.ByteTensor([[1, 1, 1], [1, 1, 0]])
         self.labels = torch.LongTensor([[0, 2, 3], [1, 4, 1]])
         self.hidden = torch.autograd.Variable(
             torch.randn(self.batch_size, self.sequence_size, self.num_labels),
-            requires_grad=True
+            requires_grad=True,
         )
 
     def test_initialize_variables(self):
 
-        self.assertEqual(self.crf.num_labels,
-                         self.num_labels)
-        self.assertEqual(self.crf.trans_matrix.size(),
-                         (self.num_labels, self.num_labels))
-        self.assertEqual(self.crf.start_trans.size(),
-                         (self.num_labels, ))
-        self.assertEqual(self.crf.end_trans.size(),
-                         (self.num_labels, ))
+        self.assertEqual(self.crf.num_labels, self.num_labels)
+        self.assertEqual(
+            self.crf.trans_matrix.size(), (self.num_labels, self.num_labels)
+        )
+        self.assertEqual(self.crf.start_trans.size(), (self.num_labels,))
+        self.assertEqual(self.crf.end_trans.size(), (self.num_labels,))
 
         num_labels = -1
         with self.assertRaises(ValueError) as er:
             CRF(num_labels)
         exception = er.exception
-        self.assertEqual(exception.args[0], 'invalid number of labels: -1')
+        self.assertEqual(exception.args[0], "invalid number of labels: -1")
 
     def test_initialize_score(self):
 
@@ -46,19 +43,19 @@ class TestCRF(unittest.TestCase):
 
     def test_forward(self):
         fvalue = self.crf.forward(self.hidden, self.labels, self.mask)
-        self.assertEqual(fvalue.type(), 'torch.FloatTensor')
-        self.assertEqual(fvalue.size(), (self.batch_size, ))
+        self.assertEqual(fvalue.type(), "torch.FloatTensor")
+        self.assertEqual(fvalue.size(), (self.batch_size,))
 
     def test_compute_log_likelihood(self):
         # log likelihood of denominator term
-        dllh = self.crf._compute_denominator_log_likelihood(
-            self.hidden, self.mask)
-        self.assertEqual(dllh.type(), 'torch.FloatTensor')
-        self.assertEqual(dllh.size(), (self.batch_size, ))
+        dllh = self.crf._compute_denominator_log_likelihood(self.hidden, self.mask)
+        self.assertEqual(dllh.type(), "torch.FloatTensor")
+        self.assertEqual(dllh.size(), (self.batch_size,))
         nllh = self.crf._compute_numerator_log_likelihood(
-            self.hidden, self.labels, self.mask)
-        self.assertEqual(nllh.type(), 'torch.FloatTensor')
-        self.assertEqual(nllh.size(), (self.batch_size, ))
+            self.hidden, self.labels, self.mask
+        )
+        self.assertEqual(nllh.type(), "torch.FloatTensor")
+        self.assertEqual(nllh.size(), (self.batch_size,))
 
     def test_decode(self):
         labels = self.crf.viterbi_decode(self.hidden, self.mask)
@@ -67,13 +64,8 @@ class TestCRF(unittest.TestCase):
         seq_lens = self.mask.sum(dim=1)
         self.assertEqual(len(labels[0]), seq_lens[0])
         self.assertEqual(len(labels[1]), seq_lens[1])
-        label_types = list(set([int(label)
-                                for seq in self.labels
-                                for label in seq
-                                ]))
-        self.assertTrue([label in label_types
-                         for seq in labels
-                         for label in seq])
+        label_types = list(set([int(label) for seq in self.labels for label in seq]))
+        self.assertTrue([label in label_types for seq in labels for label in seq])
 
     def test_logsumexp(self):
         lse = self.crf.logsumexp(self.hidden, -1)

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -6,16 +6,17 @@ from TorchCRF import CRF
 class TestCRF(unittest.TestCase):
     def setUp(self):
 
+        device = "cuda" if torch.cuda.is_available() else "cpu"
         self.batch_size = 2
         self.sequence_size = 3
         self.num_labels = 5
         self.crf = CRF(self.num_labels)
-        self.mask = torch.ByteTensor([[1, 1, 1], [1, 1, 0]])
-        self.labels = torch.LongTensor([[0, 2, 3], [1, 4, 1]])
+        self.mask = torch.ByteTensor([[1, 1, 1], [1, 1, 0]]).to(device)
+        self.labels = torch.LongTensor([[0, 2, 3], [1, 4, 1]]).to(device)
         self.hidden = torch.autograd.Variable(
             torch.randn(self.batch_size, self.sequence_size, self.num_labels),
             requires_grad=True,
-        )
+        ).to(device)
 
     def test_initialize_variables(self):
 
@@ -43,18 +44,27 @@ class TestCRF(unittest.TestCase):
 
     def test_forward(self):
         fvalue = self.crf.forward(self.hidden, self.labels, self.mask)
-        self.assertEqual(fvalue.type(), "torch.FloatTensor")
+        if torch.cuda.is_available():
+            self.assertEqual(fvalue.type(), "torch.cuda.FloatTensor")
+        else:
+            self.assertEqual(fvalue.type(), "torch.FloatTensor")
         self.assertEqual(fvalue.size(), (self.batch_size,))
 
     def test_compute_log_likelihood(self):
         # log likelihood of denominator term
         dllh = self.crf._compute_denominator_log_likelihood(self.hidden, self.mask)
-        self.assertEqual(dllh.type(), "torch.FloatTensor")
+        if torch.cuda.is_available():
+            self.assertEqual(dllh.type(), "torch.cuda.FloatTensor")
+        else:
+            self.assertEqual(dllh.type(), "torch.FloatTensor")
         self.assertEqual(dllh.size(), (self.batch_size,))
         nllh = self.crf._compute_numerator_log_likelihood(
             self.hidden, self.labels, self.mask
         )
-        self.assertEqual(nllh.type(), "torch.FloatTensor")
+        if torch.cuda.is_available():
+            self.assertEqual(nllh.type(), "torch.cuda.FloatTensor")
+        else:
+            self.assertEqual(nllh.type(), "torch.FloatTensor")
         self.assertEqual(nllh.size(), (self.batch_size,))
 
     def test_decode(self):


### PR DESCRIPTION
Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.